### PR TITLE
Add whitelisting via procfile, use basic_consume to listen for messages.

### DIFF
--- a/shove/shove.py
+++ b/shove/shove.py
@@ -1,51 +1,70 @@
+import json
 import logging
 import os
 import sys
-import time
 
 import pika
-from honcho.process import Process, ProcessManager
+from honcho.process import Process
+from honcho.procfile import Procfile
 
 
 logging.basicConfig(format='%(levelname)s: %(message)s', level=logging.INFO)
 log = logging.getLogger(__name__)
 
-process_manager = ProcessManager()
 
-
-def blocking_queue():
-    """Create up a queue connection and returns a generator of blocking reads.
-    """
+def create_channel():
+    """Create a channel for communicating with RabbitMQ."""
     params = pika.ConnectionParameters(
-        host=os.environ.get("RABBITMQ_HOST"),
-        port=int(os.environ.get("RABBITMQ_PORT")),
-        virtual_host=os.environ.get("RABBITMQ_VHOST"),
+        host=os.environ.get('RABBITMQ_HOST', 'localhost'),
+        port=int(os.environ.get('RABBITMQ_PORT', 5672)),
+        virtual_host=os.environ.get('RABBITMQ_VHOST', '/'),
         credentials=pika.credentials.PlainCredentials(
-            os.environ.get("RABBITMQ_USER"),
-            os.environ.get("RABBITMQ_PASS")
+            os.environ.get('RABBITMQ_USER', 'guest'),
+            os.environ.get('RABBITMQ_PASS', 'guest')
         )
     )
-    queue = os.environ.get("CAP_SHOVE_QUEUE", "default")
-    channel = pika.BlockingConnection(params).channel()
-    while (True):
-        _, _, body = channel.basic_get(queue=queue, no_ack=True)
-        if not body:
-            print "Nothing yet, having a quick nap."
-            time.sleep(5)
-            continue
-        yield body
+
+    return pika.BlockingConnection(params).channel()
 
 
-def run(cmd):
-    """Run a single command and exit"""
-    p = Process(cmd, stdout=sys.stdout, stderr=sys.stderr)
+def parse_order(order_body):
+    return json.loads(order_body)
+
+
+def run(order):
+    """Run a single order and exit."""
+    procfile_path = os.path.join(order['project_path'], 'bin', 'commands.procfile')
+    with open(procfile_path, 'r') as f:
+        procfile = Procfile(f.read())
+
+    command = procfile.commands.get(order['command'])
+    if not command:
+        log.warning('No command `{0}` found in {1}'.format(order['command'], procfile_path))
+        return
+
+    p = Process(command, cwd=order['project_path'], stdout=sys.stdout, stderr=sys.stderr)
     p.wait()
-    print "finished running %s - returned %s" % (cmd, p.returncode)
+    log.info('Finished running {0} - returned {1}'.format(command, p.returncode))
+
+
+def consume_message(ch, method, properties, body):
+    """Consume a message from the queue."""
+    order = parse_order(body)
+    run(order)
 
 
 def main():
-    for command in blocking_queue():
-        run(command)
+    channel = create_channel()
+    queue = os.environ.get('CAP_SHOVE_QUEUE', 'captain_shove')
+    channel.queue_declare(queue=queue, durable=True)
+    channel.basic_consume(consume_message, queue=queue, no_ack=True)
+    log.info('Awaiting orders, sir!')
+    try:
+        channel.start_consuming()
+    except KeyboardInterrupt:
+        log.info('Standing down and returning to base, sir!')
+    finally:
+        channel.close(reply_text='Shove standing down, sir!')
 
 
 if __name__ == '__main__':

--- a/tests/test_project/bin/commands.procfile
+++ b/tests/test_project/bin/commands.procfile
@@ -1,0 +1,2 @@
+ping: echo 'pong'
+pwd: pwd


### PR DESCRIPTION
Removes manual wait loop and uses basic_consume to register a consumer
for messages from rabbitmq. Also adds support for parsing procfiles and
using them as a whitelist for commands.

Fixes up some formatting/PEP8 issues as well, and adds defaults for
rabbitmq connection settings to make local development easier.

There are still some things missing from this; notably, the publisher can tell shove where to look for the procfile, which means that it can get shove to run commands from any procfile it has read access to. This is a problem we'll deal with in another pull request, though.
